### PR TITLE
Add "data" and "data_local" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Requires `allow-env` permission.
 
 Returns `null` if there is no applicable directory or if any other error occurs.
 
-Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"download"`,
+Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"data_local"`,
+`"download"`,
 
-Not yet implemented: `"executable"`, `"data_local"`, `"audio"`, `"desktop"`,
-`"document"` `"font"`, `"picture"`, `"public"`, `"template"`, `"tmp"`, `"video"`
+Not yet implemented: `"executable"`, `"audio"`, `"desktop"`, `"document"`
+`"font"`, `"picture"`, `"public"`, `"template"`, `"tmp"`, `"video"`
 
 `"home"`
 
@@ -76,7 +77,7 @@ Not yet implemented: `"executable"`, `"data_local"`, `"audio"`, `"desktop"`,
 | -------- | ---------------------------------------- | -------------------------------------------- |
 | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
 | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
-| Windows  | `{FOLDERID_LocalAppData}`                | C:\Users\justjavac\AppData\Local             |
+| Windows  | `$LOCALAPPDATA`                          | C:\Users\justjavac\AppData\Local             |
 
 `"audio"`
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ Requires `allow-env` permission.
 
 Returns `null` if there is no applicable directory or if any other error occurs.
 
-Argument values: `"home"`, `"cache"`, `"config"`, `"download"`,
+Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"download"`,
 
-Not yet implemented: `"executable"`, `"data"`, `"data_local"`, `"audio"`,
-`"desktop"`, `"document"` `"font"`, `"picture"`, `"public"`, `"template"`,
-`"tmp"`, `"video"`
+Not yet implemented: `"executable"`, `"data_local"`, `"audio"`, `"desktop"`,
+`"document"` `"font"`, `"picture"`, `"public"`, `"template"`, `"tmp"`, `"video"`
 
 `"home"`
 
@@ -69,7 +68,7 @@ Not yet implemented: `"executable"`, `"data"`, `"data_local"`, `"audio"`,
 | -------- | ---------------------------------------- | -------------------------------------------- |
 | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
 | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
-| Windows  | `{FOLDERID_RoamingAppData}`              | C:\Users\justjavac\AppData\Roaming           |
+| Windows  | `$APPDATA`                               | C:\Users\justjavac\AppData\Roaming           |
 
 `"data_local"`
 

--- a/data_dir/README.md
+++ b/data_dir/README.md
@@ -1,0 +1,27 @@
+# data_dir
+
+Returns the path to the user's data directory.
+
+The returned value depends on the operating system and is either a string,
+containing a value from the following table, or `null`.
+
+| Platform | Value                                    | Example                                      |
+| -------- | ---------------------------------------- | -------------------------------------------- |
+| Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+| macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+| Windows  | `$APPDATA`                               | C:\Users\justjavac\AppData\Roaming           |
+
+## Usage
+
+Requires `allow-env` permission.
+
+Returns `null` if there is no applicable directory or if any other error occurs.
+
+```ts
+import data_dir from "https://deno.land/x/dir/data_dir/mod.ts";
+
+data_dir();
+// Lin: "/home/justjavac/.local/share"
+// Mac: "/Users/justjavac/Library/Application Support"
+// Win: "C:\Users\justjavac\AppData\Roaming"
+```

--- a/data_dir/mod.ts
+++ b/data_dir/mod.ts
@@ -1,0 +1,34 @@
+/** Returns the path to the user's data directory.
+ *
+ * The returned value depends on the operating system and is either a string,
+ * containing a value from the following table, or `null`.
+ *
+ * | Platform | Value                                    | Example                                      |
+ * | -------- | ---------------------------------------- | -------------------------------------------- |
+ * | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+ * | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+ * | Windows  | `$APPDATA`                               | C:\Users\justjavac\AppData\Roaming           |
+ */
+export default function dataDir(): string | null {
+  switch (Deno.build.os) {
+    case "linux": {
+      const xdg = Deno.env.get("XDG_DATA_HOME");
+      if (xdg) return xdg;
+
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/.local/share`;
+      break;
+    }
+
+    case "darwin": {
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/Library/Application Support`;
+      break;
+    }
+
+    case "windows":
+      return Deno.env.get("APPDATA") ?? null;
+  }
+
+  return null;
+}

--- a/data_local_dir/README.md
+++ b/data_local_dir/README.md
@@ -1,0 +1,27 @@
+# data_local_dir
+
+Returns the path to the user's local data directory.
+
+The returned value depends on the operating system and is either a string,
+containing a value from the following table, or `null`.
+
+| Platform | Value                                    | Example                                      |
+| -------- | ---------------------------------------- | -------------------------------------------- |
+| Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+| macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+| Windows  | `$LOCALAPPDATA`                          | C:\Users\justjavac\AppData\Local             |
+
+## Usage
+
+Requires `allow-env` permission.
+
+Returns `null` if there is no applicable directory or if any other error occurs.
+
+```ts
+import data_local_dir from "https://deno.land/x/dir/data_local/mod.ts";
+
+data_local_dir();
+// Lin: "/home/justjavac/.local/share"
+// Mac: "/Users/justjavac/Library/Application Support"
+// Win: "C:\Users\justjavac\AppData\Local"
+```

--- a/data_local_dir/mod.ts
+++ b/data_local_dir/mod.ts
@@ -1,0 +1,34 @@
+/** Returns the path to the user's local data directory.
+ *
+ * The returned value depends on the operating system and is either a string,
+ * containing a value from the following table, or `null`.
+ *
+ * | Platform | Value                                    | Example                                      |
+ * | -------- | ---------------------------------------- | -------------------------------------------- |
+ * | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+ * | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+ * | Windows  | `$LOCALAPPDATA`                          | C:\Users\justjavac\AppData\Local             |
+ */
+export default function dataDir(): string | null {
+  switch (Deno.build.os) {
+    case "linux": {
+      const xdg = Deno.env.get("XDG_DATA_HOME");
+      if (xdg) return xdg;
+
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/.local/share`;
+      break;
+    }
+
+    case "darwin": {
+      const home = Deno.env.get("HOME");
+      if (home) return `${home}/Library/Application Support`;
+      break;
+    }
+
+    case "windows":
+      return Deno.env.get("LOCALAPPDATA") ?? null;
+  }
+
+  return null;
+}

--- a/mod.ts
+++ b/mod.ts
@@ -2,6 +2,7 @@ import home_dir from "./home_dir/mod.ts";
 import cache_dir from "./cache_dir/mod.ts";
 import config_dir from "./config_dir/mod.ts";
 import data_dir from "./data_dir/mod.ts";
+import data_local_dir from "./data_local_dir/mod.ts";
 import download_dir from "./download_dir/mod.ts";
 
 export type DirKind =
@@ -9,10 +10,10 @@ export type DirKind =
   | "cache"
   | "config"
   | "data"
+  | "data_local"
   | "download";
 
 // | "executable"
-// | "data_local"
 // | "audio"
 // | "desktop"
 // | "document"
@@ -35,7 +36,7 @@ export type DirKind =
  * Returns `null` if there is no applicable directory or if any other error
  * occurs.
  *
- * Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"download"`,
+ * Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"data_local"`, `"download"`,
  *
  * `"home"`
  *
@@ -79,11 +80,11 @@ export type DirKind =
  *
  * `"data_local"`
  *
- * |Platform | Value                                    | Example                                      |
- * | ------- | ---------------------------------------- | -------------------------------------------- |
- * | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
- * | macOS   | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
- * | Windows | `{FOLDERID_LocalAppData}`                | C:\Users\justjavac\AppData\Local             |
+ * | Platform | Value                                    | Example                                      |
+ * | -------- | ---------------------------------------- | -------------------------------------------- |
+ * | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+ * | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+ * | Windows  | `$LOCALAPPDATA`                          | C:\Users\justjavac\AppData\Local             |
  *
  * `"audio"`
  *
@@ -175,6 +176,8 @@ export default function dir(kind: DirKind): string | null {
       return config_dir();
     case "data":
       return data_dir();
+    case "data_local":
+      return data_local_dir();
     case "download":
       return download_dir();
     default:

--- a/mod.ts
+++ b/mod.ts
@@ -1,16 +1,17 @@
 import home_dir from "./home_dir/mod.ts";
 import cache_dir from "./cache_dir/mod.ts";
 import config_dir from "./config_dir/mod.ts";
+import data_dir from "./data_dir/mod.ts";
 import download_dir from "./download_dir/mod.ts";
 
 export type DirKind =
   | "home"
   | "cache"
   | "config"
+  | "data"
   | "download";
 
 // | "executable"
-// | "data"
 // | "data_local"
 // | "audio"
 // | "desktop"
@@ -34,7 +35,7 @@ export type DirKind =
  * Returns `null` if there is no applicable directory or if any other error
  * occurs.
  *
- * Argument values: `"home"`, `"cache"`, `"config"`, `"download"`,
+ * Argument values: `"home"`, `"cache"`, `"config"`, `"data"`, `"download"`,
  *
  * `"home"`
  *
@@ -70,11 +71,11 @@ export type DirKind =
  *
  * `"data"`
  *
- * |Platform | Value                                    | Example                                      |
- * | ------- | ---------------------------------------- | -------------------------------------------- |
- * | Linux   | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
- * | macOS   | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
- * | Windows | `{FOLDERID_RoamingAppData}`              | C:\Users\justjavac\AppData\Roaming           |
+ * | Platform | Value                                    | Example                                      |
+ * | -------- | ---------------------------------------- | -------------------------------------------- |
+ * | Linux    | `$XDG_DATA_HOME` or `$HOME`/.local/share | /home/justjavac/.local/share                 |
+ * | macOS    | `$HOME`/Library/Application Support      | /Users/justjavac/Library/Application Support |
+ * | Windows  | `$APPDATA`                               | C:\Users\justjavac\AppData\Roaming           |
  *
  * `"data_local"`
  *
@@ -172,6 +173,8 @@ export default function dir(kind: DirKind): string | null {
       return cache_dir();
     case "config":
       return config_dir();
+    case "data":
+      return data_dir();
     case "download":
       return download_dir();
     default:

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -12,6 +12,9 @@ Deno.test("test that dir return value is not null and length is more than 0", ()
   const config = dir("config");
   assert(config?.length && config.length > 0);
 
+  const data = dir("data");
+  assert(data?.length && data.length > 0);
+
   const download = dir("download");
   assert(download?.length && download.length > 0);
 });

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -15,6 +15,9 @@ Deno.test("test that dir return value is not null and length is more than 0", ()
   const data = dir("data");
   assert(data?.length && data.length > 0);
 
+  const data_local = dir("data_local");
+  assert(data_local?.length && data_local.length > 0);
+
   const download = dir("download");
   assert(download?.length && download.length > 0);
 });


### PR DESCRIPTION
Implements `dir("data")` and `dir("data_local")`. Based on the other implementations and https://github.com/justjavac/deno_data_dir.