### PR TITLE
chore: move to latest std version

### DIFF
--- a/download_dir/mod.ts
+++ b/download_dir/mod.ts
@@ -1,4 +1,4 @@
-import { join } from "https://deno.land/std@0.141.0/path/mod.ts";
+import { join } from "https://deno.land/std@0.204.0/path/join.ts";
 import home_dir from "../home_dir/mod.ts";
 
 /** Returns the path to the user's download directory.

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "https://deno.land/std@0.150.0/testing/asserts.ts";
+import { assert } from "https://deno.land/std@0.204.0/assert/assert.ts";
 
 import dir from "./mod.ts";
 


### PR DESCRIPTION
This is blocking adoption over at Astral.

ref: https://github.com/lino-levan/astral/issues/37